### PR TITLE
Update for SMAPI 3.0 & rewrite implementation

### DIFF
--- a/CarryChest.csproj
+++ b/CarryChest.csproj
@@ -2,9 +2,6 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <DeployModFolderName>$(MSBuildProjectName)</DeployModFolderName>
-  </PropertyGroup>
-  <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{218D2AAC-1C05-4D68-8EFB-7B244A1F2606}</ProjectGuid>
@@ -52,7 +49,7 @@
     <None Include="manifest.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.1.0" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.2.0" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/CarryChest.csproj
+++ b/CarryChest.csproj
@@ -14,8 +14,6 @@
     <AssemblyName>CarryChest</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -52,17 +50,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="manifest.json" />
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.1.0" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
-  </Target>
 </Project>

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "Name": "Carry Chest",
   "Author": "spacechase0",
   "Version": "1.2.2",
-  "Description": "...",
+  "Description": "Carry chests with their contents.",
   "UniqueID": "spacechase0.CarryChest",
   "PerSaveConfigs": false,
   "EntryDll": "CarryChest.dll",

--- a/manifest.json
+++ b/manifest.json
@@ -4,8 +4,8 @@
   "Version": "1.2.2",
   "Description": "Carry chests with their contents.",
   "UniqueID": "spacechase0.CarryChest",
-  "PerSaveConfigs": false,
   "EntryDll": "CarryChest.dll",
+  "MinimumApiVersion": "2.9.0",
   "UpdateKeys": [ "Nexus:1333", "Chucklefish:4851" ],
   "spacechase0": "carry-chest"
 }

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0" targetFramework="net452" />
-</packages>


### PR DESCRIPTION
This pull request rewrites the mod using new SMAPI events and a guaranteed event order, so it now performs its logic within each update tick independently. That should make the code more robust and less prone to race conditions. In particular...

* fixed some non-player chests being carryable;
* fixed chest name lost when chest is placed;
* fixed chest contents sometimes disappearing (in theory);
* fixed potential bugs due to non-guaranteed event order.

Aside from the rewrite, this pull request...

* updates the code for SMAPI 3.0 (still compatible with current versions of SMAPI);
* updates the mod build package and simplifies the build settings;
* migrates to the new package reference format;
* adds a description to the `manifest.json`.

Let me know if you want me to change anything!